### PR TITLE
Multiple divers of same name would only show the last one parsed

### DIFF
--- a/DiveMeets/DiveMeets/Parsers/HTMLParser.swift
+++ b/DiveMeets/DiveMeets/Parsers/HTMLParser.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 import SwiftSoup
 
+typealias DiverProfileRecords = [String: [String]]
+
 final class HTMLParser: ObservableObject {
     @Published var myData = [[String]]()
     let getTextModel = GetTextAsyncModel()
@@ -82,9 +84,9 @@ final class HTMLParser: ObservableObject {
     }
     
     
-    func getRecords(_ html: String) -> [String: String] {
+    func getRecords(_ html: String) -> DiverProfileRecords {
         let leadingLink: String = "https://secure.meetcontrol.com/divemeets/system/"
-        var result: [String: String] = [:]
+        var result: DiverProfileRecords = [:]
         do {
             let document: Document = try SwiftSoup.parse(html)
             guard let body = document.body() else {
@@ -93,7 +95,11 @@ final class HTMLParser: ObservableObject {
             let content = try body.getElementById("dm_content")
             let links = try content?.getElementsByClass("showresults").select("a")
             try links?.forEach({ l in
-                result[try l.text()] = try leadingLink + l.attr("href")
+                // Adds an empty list value to a new key
+                if !result.keys.contains(try l.text()) {
+                    result[try l.text()] = []
+                }
+                result[try l.text()]!.append(try leadingLink + l.attr("href"))
             })
         }
         catch {

--- a/DiveMeets/DiveMeets/Views/Search/RecordList.swift
+++ b/DiveMeets/DiveMeets/Views/Search/RecordList.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct RecordList: View {
     @Environment(\.colorScheme) var currentMode
-    @Binding var records: [String: String]
+    @Binding var records: DiverProfileRecords
     @Binding var resultSelected: Bool
     
     // Style adjustments for elements of list
@@ -27,6 +27,18 @@ struct RecordList: View {
         return Color(red: gray, green: gray, blue: gray)
     }
     
+    // Converts keys and lists of values into tuples of key and value
+    private func getSortedRecords(_ records: DiverProfileRecords) -> [(String, String)] {
+        var result: [(String, String)] = []
+        for (key, value) in records {
+            for link in value {
+                result.append((key, link))
+            }
+        }
+        
+        return result.sorted(by: { $0.0 < $1.0 })
+    }
+    
     var body: some View {
         NavigationView {
             ZStack {
@@ -35,30 +47,31 @@ struct RecordList: View {
                 
                 ScrollView(.vertical, showsIndicators: false) {
                     VStack(spacing: rowSpacing) {
-                        ForEach(records.sorted(by: <), id: \.key) { key, value in
+                        ForEach(getSortedRecords(records), id: \.1) { record in
+                            let (key, value) = record
                             NavigationLink(destination: ProfileView(profileLink: value)) {
-                                            HStack {
-                                                Text(key)
-                                                    .foregroundColor(textColor)
-                                                    .font(.title3)
-                                                    .padding()
-                                                
-                                                Spacer()
-                                                
-                                                Image(systemName: "chevron.right")
-                                                    .foregroundColor(Color.gray)
-                                                    .padding()
-                                            }
-                                            .background(rowColor)
-                                            .cornerRadius(cornerRadius)
-                                        .onDisappear {
-                                            resultSelected = true
-                                        }
-                                        .onAppear{
-                                            resultSelected = false
-                                        }
-                                    }
-                                    .padding([.leading, .trailing])
+                                HStack {
+                                    Text(key)
+                                        .foregroundColor(textColor)
+                                        .font(.title3)
+                                        .padding()
+                                    
+                                    Spacer()
+                                    
+                                    Image(systemName: "chevron.right")
+                                        .foregroundColor(Color.gray)
+                                        .padding()
+                                }
+                                .background(rowColor)
+                                .cornerRadius(cornerRadius)
+                                .onDisappear {
+                                    resultSelected = true
+                                }
+                                .onAppear{
+                                    resultSelected = false
+                                }
+                            }
+                            .padding([.leading, .trailing])
                         }
                     }
                     .padding()
@@ -66,16 +79,6 @@ struct RecordList: View {
                 .navigationTitle("Results")
                 .padding(.bottom, viewPadding)
             }
-        }
-    }
-}
-
-struct RecordList_Previews: PreviewProvider {
-    static var previews: some View {
-        ForEach(ColorScheme.allCases, id: \.self) {
-            RecordList(records: .constant(["Logan": "google.com"]),
-                       resultSelected: .constant(false))
-                .preferredColorScheme($0)
         }
     }
 }

--- a/DiveMeets/DiveMeets/Views/Search/SearchView.swift
+++ b/DiveMeets/DiveMeets/Views/Search/SearchView.swift
@@ -190,7 +190,7 @@ struct SearchView: View {
     @State private var orgName: String = ""
     @State private var meetYear: String = ""
     @State private var searchSubmitted: Bool = false
-    @State var parsedLinks: [String: String] = [:]
+    @State var parsedLinks: DiverProfileRecords = [:]
     @State var dmSearchSubmitted: Bool = false
     @State var linksParsed: Bool = false
     @Binding var isIndexingMeets: Bool
@@ -241,7 +241,7 @@ struct SearchInputView: View {
     @Binding var meetYear: String
     @Binding var searchSubmitted: Bool
     
-    @Binding var parsedLinks: [String: String]
+    @Binding var parsedLinks: DiverProfileRecords
     @Binding var dmSearchSubmitted: Bool
     @Binding var linksParsed: Bool
     @Binding var isIndexingMeets: Bool
@@ -599,7 +599,7 @@ struct DiverSearchView: View {
                     .textFieldStyle(.roundedBorder)
                     .padding(.trailing)
                     .focused(focusedField, equals: .lastName)
-                    
+                
             }
         }
         .padding()
@@ -723,7 +723,7 @@ struct MeetResultsView : View {
                                 .foregroundColor(currentMode == .light ? .white : .black)
                             VStack {
                                 if let name = e.name, let city = e.city, let state = e.state,
-                                    let startDate = e.startDate, let endDate = e.endDate {
+                                   let startDate = e.startDate, let endDate = e.endDate {
                                     HStack(alignment: .top) {
                                         Text(name)
                                             .font(.title3)

--- a/DiveMeets/DiveMeets/Views/Util/SwiftUIWebView.swift
+++ b/DiveMeets/DiveMeets/Views/Util/SwiftUIWebView.swift
@@ -14,7 +14,7 @@ struct SwiftUIWebView: View {
     @State var request: String =
     "https://secure.meetcontrol.com/divemeets/system/memberlist.php"
     @State var parsedHTML: String = ""
-    @Binding var parsedLinks: [String: String]
+    @Binding var parsedLinks: DiverProfileRecords
     @Binding var dmSearchSubmitted: Bool
     @Binding var linksParsed: Bool
     
@@ -31,7 +31,7 @@ struct WebView: UIViewRepresentable {
     let htmlParser: HTMLParser = HTMLParser()
     @Binding var request: String
     @Binding var parsedHTML: String
-    @Binding var parsedLinks: [String: String]
+    @Binding var parsedLinks: DiverProfileRecords
     @Binding var firstName: String
     @Binding var lastName: String
     @Binding var dmSearchSubmitted: Bool
@@ -69,13 +69,13 @@ struct WebView: UIViewRepresentable {
     class Coordinator: NSObject, WKNavigationDelegate {
         let htmlParser: HTMLParser = HTMLParser()
         @Binding var parsedHTML: String
-        @Binding var parsedLinks: [String: String]
+        @Binding var parsedLinks: DiverProfileRecords
         @Binding var firstName: String
         @Binding var lastName: String
         @Binding var dmSearchSubmitted: Bool
         @Binding var linksParsed: Bool
         
-        init(html: Binding<String>, links: Binding<[String: String]>, firstName: Binding<String>,
+        init(html: Binding<String>, links: Binding<DiverProfileRecords>, firstName: Binding<String>,
              lastName: Binding<String>, dmSearchSubmitted: Binding<Bool>,
              linksParsed: Binding<Bool>) {
             self._parsedHTML = html


### PR DESCRIPTION
- Changed the parsedLinks dict from [String: String] to [String: [String]] to hold each unique link to the same name
- Converts that new type into records of type (String, String), where the key is matched to its link and name keys could be duplicated