### PR TITLE
Fix meet picker sticking when indexing is occurring

### DIFF
--- a/DiveMeets/DiveMeets.xcodeproj/project.pbxproj
+++ b/DiveMeets/DiveMeets.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		0037877A29D4F40900D3CD59 /* ProfileMeetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0037877829D4F40900D3CD59 /* ProfileMeetCache.swift */; };
 		0037877C29D4F41800D3CD59 /* MeetParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0037877B29D4F41800D3CD59 /* MeetParser.swift */; };
 		0037878029D501F600D3CD59 /* ProfileParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0037877F29D501F600D3CD59 /* ProfileParser.swift */; };
+		0040A6B72A550C8E004C84BF /* NoStickPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0040A6B62A550C8E004C84BF /* NoStickPicker.swift */; };
 		0065C5AA2A426D9E0040600E /* TileSwapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C5A92A426D9E0040600E /* TileSwapView.swift */; };
 		0065C5AC2A4377920040600E /* SwipeModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C5AB2A4377920040600E /* SwipeModifier.swift */; };
 		0069DC5B2A0DC5610096C04B /* ScalingScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0069DC5A2A0DC5610096C04B /* ScalingScrollView.swift */; };
@@ -78,6 +79,7 @@
 		0037877829D4F40900D3CD59 /* ProfileMeetCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProfileMeetCache.swift; path = DiveMeets/Model/ProfileMeetCache.swift; sourceTree = SOURCE_ROOT; };
 		0037877B29D4F41800D3CD59 /* MeetParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeetParser.swift; sourceTree = "<group>"; };
 		0037877F29D501F600D3CD59 /* ProfileParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileParser.swift; sourceTree = "<group>"; };
+		0040A6B62A550C8E004C84BF /* NoStickPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoStickPicker.swift; sourceTree = "<group>"; };
 		0065C5A92A426D9E0040600E /* TileSwapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileSwapView.swift; sourceTree = "<group>"; };
 		0065C5AB2A4377920040600E /* SwipeModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeModifier.swift; sourceTree = "<group>"; };
 		0069DC5A2A0DC5610096C04B /* ScalingScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScalingScrollView.swift; sourceTree = "<group>"; };
@@ -318,6 +320,7 @@
 				0065C5AB2A4377920040600E /* SwipeModifier.swift */,
 				4D26F43B2A4FEC3200DA0E98 /* SwiftUIWheelPicker.swift */,
 				0065C5A92A426D9E0040600E /* TileSwapView.swift */,
+				0040A6B62A550C8E004C84BF /* NoStickPicker.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -400,6 +403,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4D753DE32A2158370029138B /* EventPageParser.swift in Sources */,
+				0040A6B72A550C8E004C84BF /* NoStickPicker.swift in Sources */,
 				4DC2DAF22A422193008CCE5A /* Colors.swift in Sources */,
 				00F9667B29AFDA1500F3720B /* ContentView.swift in Sources */,
 				4D60E8F92A1737A90011A295 /* ScoringParser.swift in Sources */,

--- a/DiveMeets/DiveMeets/Parsers/MeetPageParser.swift
+++ b/DiveMeets/DiveMeets/Parsers/MeetPageParser.swift
@@ -546,13 +546,11 @@ class MeetPageParser: ObservableObject {
         let tables = try content.getElementsByTag("table")
         
         if (link.contains("meetinfo")) {
-            print("Parsing info link...")
             return parseInfoPage(tables: tables)
         } else if (link.contains("meetresults")) {
-            print("Parsing results link...")
             return parseResultsPage(tables: tables)
         }
-        print("Failed")
+        
         return nil
     }
 }

--- a/DiveMeets/DiveMeets/Views/Search/SearchView.swift
+++ b/DiveMeets/DiveMeets/Views/Search/SearchView.swift
@@ -537,15 +537,15 @@ struct SearchInputView: View {
     }
     
     private func debounceTabSelection(_ newSelection: SearchType) {
-            debounceWorkItem?.cancel() // Cancel previous debounce work item if exists
-
-            let workItem = DispatchWorkItem { [self] in
-                self.selection = newSelection
-            }
-
-            debounceWorkItem = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
+        debounceWorkItem?.cancel() // Cancel previous debounce work item if exists
+        
+        let workItem = DispatchWorkItem { [self] in
+            self.selection = newSelection
         }
+        
+        debounceWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
+    }
 }
 
 struct IndexingCounterView: View {
@@ -638,8 +638,15 @@ struct MeetSearchView: View {
     @Binding var meetName: String
     @Binding var orgName: String
     @Binding var meetYear: String
+    @State var meetYearIndex: Int = 0
     private var focusedField: FocusState<SearchField?>.Binding
     private let currentYear: Int = Calendar.current.component(.year, from: Date())
+    
+    @ScaledMetric var pickerFontSize: CGFloat = 18
+    
+    private func meetIndexToString(_ index: Int) -> String {
+        return index == 0 ? "" : String(currentYear - index + 1)
+    }
     
     fileprivate init(meetName: Binding<String>, orgName: Binding<String>,
                      meetYear: Binding<String>, focusedField: FocusState<SearchField?>.Binding) {
@@ -650,7 +657,7 @@ struct MeetSearchView: View {
     }
     
     var body: some View {
-        VStack{
+        VStack {
             HStack {
                 Text("Meet Name:")
                     .padding(.leading)
@@ -678,17 +685,22 @@ struct MeetSearchView: View {
             HStack {
                 Text("Meet Year:")
                     .padding(.leading)
-                Picker("", selection: $meetYear) {
-                    Text("").tag("")
-                    ForEach((2004...currentYear).reversed(),
-                            id: \.self) {
-                        Text(String($0))
-                            .tag(String($0))
-                    }
+                NoStickPicker(selection: $meetYearIndex,
+                              rowCount: (2004...currentYear).count + 1) { r in
+                    let label = UILabel()
+                    label.attributedText = NSMutableAttributedString(string: meetIndexToString(r))
+                    label.font = UIFont.systemFont(ofSize: pickerFontSize)
+                    label.sizeToFit()
+                    label.layer.masksToBounds = true
+                    return label
                 }
-                .pickerStyle(.wheel)
-                .frame(width: 150, height: 85)
-                .padding(.trailing)
+                              .pickerStyle(.wheel)
+                              .frame(width: 125, height: 85)
+                              .padding(.trailing)
+                              .onChange(of: meetYearIndex) { newValue in
+                                  meetYear = meetIndexToString(newValue)
+                                  print(meetYear)
+                              }
             }
             .offset(y: -10)
         }
@@ -742,36 +754,37 @@ struct MeetResultsView : View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 if !records.isEmpty {
                     ScalingScrollView(records: records, rowSpacing: rowSpacing) { (e) in
-                        ZStack {
-                            Rectangle()
-                                .foregroundColor(currentMode == .light ? .white : .black)
-                            VStack {
-                                if let name = e.name, let city = e.city, let state = e.state,
-                                   let startDate = e.startDate, let endDate = e.endDate {
-                                    HStack(alignment: .top) {
-                                        Text(name)
-                                            .font(.title3)
-                                            .bold()
+                        NavigationLink(destination: MeetPageView(meetLink: e.link ?? "")) {
+                            ZStack {
+                                Rectangle()
+                                    .foregroundColor(currentMode == .light ? .white : .black)
+                                VStack {
+                                    if let name = e.name, let city = e.city, let state = e.state,
+                                       let startDate = e.startDate, let endDate = e.endDate {
+                                        HStack(alignment: .top) {
+                                            Text(name)
+                                                .font(.title3)
+                                                .bold()
+                                            Spacer()
+                                            Text(city + ", " + state)
+                                        }
+                                        .foregroundColor(.primary)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                        .lineLimit(2)
                                         Spacer()
-                                        Text(city + ", " + state)
+                                        HStack {
+                                            Text(e.organization ?? "")
+                                            Spacer()
+                                            Text(dateToString(startDate)
+                                                 + " - " + dateToString(endDate))
+                                        }
+                                        .foregroundColor(.primary)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                        .lineLimit(1)
                                     }
-                                    .fixedSize(horizontal: false, vertical: true)
-                                    .lineLimit(2)
-                                    Spacer()
-                                    HStack {
-                                        Text(e.organization ?? "")
-                                        Spacer()
-                                        Text(dateToString(startDate)
-                                             + " - " + dateToString(endDate))
-                                    }
-                                    .fixedSize(horizontal: false, vertical: true)
-                                    .lineLimit(1)
                                 }
+                                .padding()
                             }
-                            .padding()
-                        }
-                        .onTapGesture {
-                            print(e.link ?? "")
                         }
                     }
                     .padding(.bottom, maxHeightOffset)

--- a/DiveMeets/DiveMeets/Views/Util/NoStickPicker.swift
+++ b/DiveMeets/DiveMeets/Views/Util/NoStickPicker.swift
@@ -1,0 +1,76 @@
+//
+//  ImprovedPicker.swift
+//  DiveMeets
+//
+//  Created by Logan Sherwin on 7/4/23.
+//  From https://www.mbishop.name/2019/11/odd-behaviors-in-the-swiftui-picker-view/
+//
+
+import SwiftUI
+
+/**
+ iOS Picker class with the update bug which can cause the SwiftUI picker to reset.
+ */
+struct NoStickPicker: UIViewRepresentable {
+    
+    class Coordinator : NSObject, UIPickerViewDataSource, UIPickerViewDelegate {
+        @Binding var selection: Int
+        
+        var initialSelection: Int?
+        var viewForRow: (Int) -> UIView
+        var rowCount: Int
+        
+        func numberOfComponents(in pickerView: UIPickerView) -> Int {
+            1
+        }
+        
+        func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+            rowCount
+        }
+        
+        func pickerView(_ pickerView: UIPickerView, viewForRow row: Int,
+                        forComponent component: Int, reusing view: UIView?) -> UIView {
+            viewForRow(row)
+        }
+        
+        func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int,
+                        inComponent component: Int) {
+            self.selection = row
+        }
+        
+        init(selection: Binding<Int>, viewForRow: @escaping (Int) -> UIView, rowCount: Int) {
+            self.viewForRow = viewForRow
+            self._selection = selection
+            self.rowCount = rowCount
+        }
+    }
+    
+    @Binding var selection: Int
+    
+    var rowCount: Int
+    let viewForRow: (Int) -> UIView
+    
+    func makeCoordinator() -> NoStickPicker.Coordinator {
+        return Coordinator(selection: $selection, viewForRow: viewForRow, rowCount: rowCount)
+    }
+    
+    func makeUIView(context: UIViewRepresentableContext<NoStickPicker>) -> UIPickerView {
+        let view = UIPickerView(frame: .zero)
+        view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        view.setContentCompressionResistancePriority(.init(20), for: .vertical)
+        view.delegate = context.coordinator
+        view.dataSource = context.coordinator
+        return view
+    }
+    
+    func updateUIView(_ uiView: UIPickerView, context: UIViewRepresentableContext<NoStickPicker>) {
+        
+        context.coordinator.viewForRow = self.viewForRow
+        context.coordinator.rowCount = rowCount
+        
+        if context.coordinator.initialSelection != selection {
+            uiView.selectRow(selection, inComponent: 0, animated: true)
+            context.coordinator.initialSelection = selection
+        }
+    }
+}


### PR DESCRIPTION
- Removed extraneous prints from MeetPageParser
- Replaced Meet Year picker with UIPicker and UIViewRepresentable that only replaces the selection when it differs from the original selection
- Created UILabel for each row in the Picker
- Added MeetPageView navigation links to meet results (because I didn't add them way back when I finished the MeetPage oops)

@spencerdearman Give it a try on your own and let me know what you think. I tried to get the appearance as close as it was before, but UIKit is extremely difficult to use.