### PR TITLE
Keep disclosure group states from resetting after clicking nav link

### DIFF
--- a/DiveMeets/DiveMeets/Parsers/EventParser.swift
+++ b/DiveMeets/DiveMeets/Parsers/EventParser.swift
@@ -138,7 +138,6 @@ final class EventHTMLParser: ObservableObject {
         eventPageLink = "https://secure.meetcontrol.com/divemeets/system/" +
         (try overall[2].getElementsByTag("a").attr("href"))
         
-        print("Here is the link:" + String(try overall[1].getElementsByTag("a").attr("href")))
         meetDates = try overall[1].getElementsByTag("Strong").text()
         totalNetScore = Double(try finalRow[2].text()) ?? 0.0
         totalDD = Double(try finalRow[3].text()) ?? 0.0

--- a/DiveMeets/DiveMeets/Views/Login/Event.swift
+++ b/DiveMeets/DiveMeets/Views/Login/Event.swift
@@ -44,9 +44,6 @@ struct Event: View {
                         .font(.title)
                         .fontWeight(.bold)
                         .padding()
-                        .onAppear{
-                            print(scoreDictionary)
-                        }
                     
                     Divider()
                     Text("Dates: " + diverData.1)

--- a/DiveMeets/DiveMeets/Views/Search/SearchView.swift
+++ b/DiveMeets/DiveMeets/Views/Search/SearchView.swift
@@ -699,7 +699,6 @@ struct MeetSearchView: View {
                               .padding(.trailing)
                               .onChange(of: meetYearIndex) { newValue in
                                   meetYear = meetIndexToString(newValue)
-                                  print(meetYear)
                               }
             }
             .offset(y: -10)

--- a/DiveMeets/DiveMeets/Views/Util/SwiftUIWebView.swift
+++ b/DiveMeets/DiveMeets/Views/Util/SwiftUIWebView.swift
@@ -107,7 +107,6 @@ struct WebView: UIViewRepresentable {
                     self?.parsedHTML = html
                     self?.parsedLinks = (self?.htmlParser.getRecords(html)) ?? [:]
                     self?.linksParsed = true
-                    print((self?.parsedLinks) ?? [:])
                 }
             }
         }


### PR DESCRIPTION
- Add global dictionary to track expansion states inside MeetList
  - Automatically clears itself on new ProfileView appearing
  - Automatically stores state when entering a nav link and reloading state and clearing dict when reappearing
- Remove extraneous prints