### PR TITLE
Speed up MeetList Render Time

### DIFF
--- a/DiveMeets/DiveMeets/Parsers/EventParser.swift
+++ b/DiveMeets/DiveMeets/Parsers/EventParser.swift
@@ -71,17 +71,11 @@ final class EventHTMLParser: ObservableObject {
                 string.append(try t.text())
                 
                 if !cachedMainMeetLinks.keys.contains(meetName) {
-                    await getTextModel.fetchText(url: URL(string: eventLink)!)
-                    if let meetHtml = getTextModel.text {
-                        let eventDocument: Document = try SwiftSoup.parse(meetHtml)
-                        guard let meetBody = eventDocument.body() else { return [:] }
-                        let main = try meetBody.getElementsByTag("table")
-                        let tr = try main[0].getElementsByTag("tr")[0]
-                        meetLink = try "https://secure.meetcontrol.com/divemeets/system/" + tr.getElementsByTag("a").attr("href")
-                        
-                        await MainActor.run { [meetName, meetLink] in
-                            cachedMainMeetLinks[meetName] = meetLink
-                        }
+                    meetLink = (eventLink.components(separatedBy: "&").first ?? "")
+                        .replacingOccurrences(of: "divesheet", with: "meet")
+
+                    await MainActor.run { [meetName, meetLink] in
+                        cachedMainMeetLinks[meetName] = meetLink
                     }
                 } else {
                     meetLink = cachedMainMeetLinks[meetName] ?? ""


### PR DESCRIPTION
- Discovered pattern in main meet links in relation to event links from profile
  - The event link up to the first & symbol and replacing "divesheet" with "meet" yields the main meet link
- Reduced original render time of ~7s to almost instant