### PR TITLE
Fix duplicate record problem (and other discovered bugs)

### DIFF
--- a/DiveMeets/DiveMeets/Parsers/MeetParser.swift
+++ b/DiveMeets/DiveMeets/Parsers/MeetParser.swift
@@ -251,13 +251,11 @@ final class MeetParser: ObservableObject {
                     do {
                         let resultsLinks = try meetResults.getElementsByAttribute("href")
                         
-                        if (resultsLinks.count == 0) {
-                            throw ParseError("No results page found in row")
+                        if resultsLinks.count > 0 {
+                            resultsLink = try leadingLink + resultsLinks[0].attr("href")
                         }
-                        
-                        resultsLink = try leadingLink + resultsLinks[0].attr("href")
                     } catch {
-                        print("No results page found")
+                        print("Failed to get link from meet results")
                     }
                 }
                 

--- a/DiveMeets/DiveMeets/Views/Main/ContentView.swift
+++ b/DiveMeets/DiveMeets/Views/Main/ContentView.swift
@@ -71,8 +71,8 @@ struct ContentView: View {
 //                                            FinishedLiveResultsView(link: "https://secure.meetcontrol.com/divemeets/system/livestats.php?event=stats-9050-770-9-Finished")
 //                                        }
 //                                        .navigationViewStyle(StackNavigationViewStyle())
-//                                        ToolsMenu()
-                                        MeetDBTestView()
+                                        ToolsMenu()
+                                        //MeetDBTestView()
                                     case .magnifyingglass:
                                         SearchView(isIndexingMeets: $isIndexingMeets)
                                     case .person:

--- a/DiveMeets/DiveMeets/Views/Main/ContentView.swift
+++ b/DiveMeets/DiveMeets/Views/Main/ContentView.swift
@@ -71,7 +71,8 @@ struct ContentView: View {
 //                                            FinishedLiveResultsView(link: "https://secure.meetcontrol.com/divemeets/system/livestats.php?event=stats-9050-770-9-Finished")
 //                                        }
 //                                        .navigationViewStyle(StackNavigationViewStyle())
-                                        ToolsMenu()
+//                                        ToolsMenu()
+                                        MeetDBTestView()
                                     case .magnifyingglass:
                                         SearchView(isIndexingMeets: $isIndexingMeets)
                                     case .person:

--- a/DiveMeets/DiveMeets/Views/Util/MeetDBTestView.swift
+++ b/DiveMeets/DiveMeets/Views/Util/MeetDBTestView.swift
@@ -51,12 +51,19 @@ struct MeetDBTestView: View {
                         db.dropAllRecords()
                     }
                     Spacer()
-                    Button("Add Past Type") {
-                        for meet in filteredMeets {
-                            meet.meetType = 2
+                    Button("Fix Dates") {
+                        for meet in meets {
+                            db.fixDates(meet)
                         }
+                        print("Fixed dates")
                     }
                     Spacer()
+                    Button("Drop Duplicates") {
+                        for meet in meets {
+                            db.dropDuplicateRecords(Int(exactly: meet.meetId)!, keepLatest: true)
+                        }
+                        print("Dropped all duplicates")
+                    }
                 }
                 .padding()
                 HStack {


### PR DESCRIPTION
- Fixed meets appearing more than once in meet search
  - Issue with meet duplicates not being detected
  - Fixed by considering duplicates to be entries that share the same meet id, and then removing them before adding a new entry if they were of earlier meet type stages (upcoming < current < past)

- Note: We should observe closely over time to be sure it is working properly, as I made significant changes to the function of this feature, but I think making sure we have unique meet ids in the database is a safe bet

- To update your database:
  - Pull this branch and run it
  - Wait for indexing to complete on the Meet search page
  - Open the Tools menu page
  - Press the "Fix Dates" button and wait for a completion print statement
  - Press the "Drop Duplicates" button and wait for a completion print statement
- This should remove all the duplicates and prevent any further conflicts in the future

*** Need to change the ContentView back to displaying the ToolsMenu view before merge